### PR TITLE
Fix loading videos

### DIFF
--- a/OpenArtemis/Utilities/Post Utils/Media Utils.swift
+++ b/OpenArtemis/Utilities/Post Utils/Media Utils.swift
@@ -55,7 +55,7 @@ class MediaUtils {
                     let doc = try SwiftSoup.parse(htmlString!)
                     
                     // Extract video link
-                    if let videoElement = try doc.select("shreddit-player source").first(),
+                    if let videoElement = try doc.select("shreddit-player-2 source").first() ?? doc.select("shreddit-player source").first(),
                        let videoUrlString = try? videoElement.attr("src"),
                        let videoUrl = URL(string: videoUrlString) {
                         completion(videoUrl)


### PR DESCRIPTION
Videos do not load due to a change in the HTML. The `<shreddit-player>` tag has been renamed to `<shreddit-player-2>`. Original `shreddit-player` selector is still used as fallback in case it is changed back again. 
