### PR TITLE
Improve post body for certain posts

### DIFF
--- a/OpenArtemis/Scrape/ScrapePostMedia.swift
+++ b/OpenArtemis/Scrape/ScrapePostMedia.swift
@@ -14,7 +14,7 @@ private let noDataError = NSError(domain: "No data received", code: 0, userInfo:
 
 extension RedditScraper {
     private static func parseUserTextBody(data: Document, trackingParamRemover: TrackingParamRemover) throws -> String? {
-        let postBody = try data.select("div.expando").first()
+        let postBody = try data.select("div.expando .usertext-body").first()
         
         var body: String? = nil
         if let bodyElement = postBody, !(try bodyElement.text().isEmpty) {


### PR DESCRIPTION
I noticed that some posts show unwanted text in the post body. This PR makes the selector for extracting the post body a bit more strict.

- Hides previous/next links for gallery posts. This is the main issue since posts with many images in the gallery can have a lot of previous/next links in the `div.expando`
- Hides image url for image posts
- Hides some technical video info ("Video Pause HD720p Auto Settings Fullscreen" etc.) on video posts [Mac/iPad only?]

It's hard to tell if this may inadvertently hide some actual body text, but it seems to work for the posts I've tried.