### PR TITLE
Typo fix in print statement

### DIFF
--- a/OpenArtemis/Scrape/HeadlessWebManager.swift
+++ b/OpenArtemis/Scrape/HeadlessWebManager.swift
@@ -55,7 +55,7 @@ class HeadlessWebManager: NSObject, WKNavigationDelegate {
     }
 
     private func allowMatureContent() {
-        print("clicing that shit")
+        print("clicking that shit")
         let jsToClickOver18Confirmation = """
         document.querySelector('button.c-btn.c-btn-primary[type="submit"][name="over18"][value="yes"]').click();
         """


### PR DESCRIPTION
Description:

- Simply fixes a typo in a print statement for logging purposes.

Changes Made:

- Changed "clicing" to "clicking"
