### PR TITLE
Comment collapsing chevron improvement

### DIFF
--- a/OpenArtemis/Views/Posts/PostPageView.swift
+++ b/OpenArtemis/Views/Posts/PostPageView.swift
@@ -117,7 +117,7 @@ struct PostPageView: View {
                                     }
                                 }
                                 .gestureActions(
-                                    primaryLeadingAction: GestureAction(symbol: .init(emptyName: "chevron.up", fillName: "chevron.up"), color: .blue, action: {
+                                    primaryLeadingAction: GestureAction(symbol: .init(emptyName: comments[index].isRootCollapsed ? "chevron.up" : "chevron.down", fillName: comments[index].isRootCollapsed ? "chevron.down" : "chevron.up"), color: .blue, action: {
                                         withAnimation(.smooth(duration: 0.35)) {
                                             if comment.parentID == nil {
                                                 comments[index].isRootCollapsed.toggle()


### PR DESCRIPTION
Description:
Chevron during post swipe gesture initially shows the current collapse state, then flips to the future collapse state once you pass the threshold of activation.

Changes Made:
Simple logic change that checks collapse mode when setting the symbols for the gestures.

Screenshots:

{Direct link or embed of image in PR comments/body}
Starting
![image](https://github.com/user-attachments/assets/db7302c8-dde2-43ac-9c34-89ad34ef29d2)
Finishing
![image](https://github.com/user-attachments/assets/bc476f89-eec4-4c86-9c86-b95de1437579)

