### PR TITLE
Added natural interactions to alert buttons and image viewer.

### DIFF
--- a/OpenArtemis.xcodeproj/project.pbxproj
+++ b/OpenArtemis.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AAF1ED42CDC0A35003E08EB /* FixAlertForMacOSStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF1ED32CDC0A32003E08EB /* FixAlertForMacOSStyle.swift */; };
 		652E2AA72B25B19C0075911F /* PrivacyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652E2AA62B25B19C0075911F /* PrivacyTab.swift */; };
 		652E2AA92B25B1F10075911F /* HeroBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652E2AA82B25B1F10075911F /* HeroBox.swift */; };
 		653245C12B2AF5D500227019 /* OOBE_PrivacySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653245BC2B2AF5D500227019 /* OOBE_PrivacySelector.swift */; };
@@ -119,6 +120,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1AAF1ED32CDC0A32003E08EB /* FixAlertForMacOSStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixAlertForMacOSStyle.swift; sourceTree = "<group>"; };
 		652E2AA62B25B19C0075911F /* PrivacyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyTab.swift; sourceTree = "<group>"; };
 		652E2AA82B25B1F10075911F /* HeroBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroBox.swift; sourceTree = "<group>"; };
 		653245BC2B2AF5D500227019 /* OOBE_PrivacySelector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OOBE_PrivacySelector.swift; sourceTree = "<group>"; };
@@ -242,6 +244,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1AAF1ED22CDC0A2D003E08EB /* Styles */ = {
+			isa = PBXGroup;
+			children = (
+				1AAF1ED32CDC0A32003E08EB /* FixAlertForMacOSStyle.swift */,
+			);
+			path = Styles;
+			sourceTree = "<group>";
+		};
 		6504FCA52B247A1400598EFF /* Privacy */ = {
 			isa = PBXGroup;
 			children = (
@@ -411,6 +421,7 @@
 		BB391FB82B1ADE3D0014FB18 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				1AAF1ED22CDC0A2D003E08EB /* Styles */,
 				BB57456B2B5322BE00A961C1 /* Markdown */,
 				BBA6FD692B45303C0096242E /* LimitedSet.swift */,
 				BB502DCF2B23AABA003C22DB /* Subreddit Utils */,
@@ -747,6 +758,7 @@
 				BB853E702B35E3210041150C /* CodableColor.swift in Sources */,
 				BB391FBA2B1ADE470014FB18 /* App Consts.swift in Sources */,
 				BB391FA62B1ADD540014FB18 /* DetailTagView.swift in Sources */,
+				1AAF1ED42CDC0A35003E08EB /* FixAlertForMacOSStyle.swift in Sources */,
 				BBACCB402B3231E100A9F550 /* TitleTagView.swift in Sources */,
 				BB391FCD2B1ADE850014FB18 /* Media Utils.swift in Sources */,
 				65A3329A2B1DDD2F00421162 /* Toaster.swift in Sources */,

--- a/OpenArtemis/Utilities/Styles/FixAlertForMacOSStyle.swift
+++ b/OpenArtemis/Utilities/Styles/FixAlertForMacOSStyle.swift
@@ -1,0 +1,16 @@
+//
+//  FixStyle.swift
+//  OpenArtemis
+//
+//  Created by Michael DiGovanni on 11/6/24.
+//
+
+import SwiftUI
+
+/// Without this style, the Save button on MacOS alters is blue, with blue text when using a default action
+/// Unsure why this works at all
+struct FixAlertForMacOSStyle: ButtonStyle {
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+    }
+}

--- a/OpenArtemis/Views/Favorites Drawer/SubredditDrawerView.swift
+++ b/OpenArtemis/Views/Favorites Drawer/SubredditDrawerView.swift
@@ -180,12 +180,12 @@ struct SubredditDrawerView: View {
                     }
                     
                     visibleSubredditSections()
-                    showSaveSubredditDialog = false
                 }
+                .keyboardShortcut(.defaultAction)
+                .disabled(subredditName.isEmpty)
+                .buttonStyle(FixAlertForMacOSStyle())
                 
-                Button("Cancel") {
-                    showSaveSubredditDialog = false
-                }
+                Button("Cancel", role: .cancel){}
             } message: {
                 Text("Enter the subreddit name you wish to add to your favorites.")
             }
@@ -195,12 +195,12 @@ struct SubredditDrawerView: View {
                 
                 Button("Save") {
                     SubredditUtils.shared.saveToMultis(managedObjectContext: managedObjectContext, name: multiName, imageURL: multiImageURL)
-                    showSaveMultiDialog = false
                 }
+                .keyboardShortcut(.defaultAction)
+                .disabled(multiName.isEmpty)
+                .buttonStyle(FixAlertForMacOSStyle())
                 
-                Button("Cancel") {
-                    showSaveMultiDialog = false
-                }
+                Button("Cancel", role: .cancel){}
             } message: {
                 Text("Enter the multi name and thumbnail image URL (optional) you wish to add to your favorites.")
             }

--- a/OpenArtemis/Views/Posts/Media/Media View Controllers/ImageViewer/ImageViewController.swift
+++ b/OpenArtemis/Views/Posts/Media/Media View Controllers/ImageViewer/ImageViewController.swift
@@ -60,6 +60,15 @@ private struct ImageView: View {
         ZStack {
             Color.black
             
+            // A hidden button to allow using the escape button to hide this, works on iPads with keyboards and mac os
+            Button(action: {
+                dismissView()
+            }) {
+                // no view
+            }
+            .hidden()
+            .keyboardShortcut(.cancelAction)
+            
             LazyPager(data: images, page: $index) { url in
                 let url = URL(string: url)
                 


### PR DESCRIPTION
Description:
Allows natural keyboard interactions on the add subreddit menus, where escape cancels, enter proceeds.

Allows escape to exit the zoomed in view of an image. This particularly helps on MacOS where dragging down sometimes will not close the image viewer, but otherwise provides a natural UX.

Overall this improves usability with no tradeoffs or regressions. Please let me know if you want tests for any of this funcitonality.

Changes Made:
Added default actions to save and cancel on 2 alert dialogs. Created a custom button style to fix a bug with the save button becoming blue with blue text on a dark theme MacOS due to the default action on the save button. This did not affect other platforms in my testing.

Subreddit alert save buttons is disabled until you type something in.

Added default action to a hidden button for dismissing the image viewer.

Screenshots:
![image](https://github.com/user-attachments/assets/55120337-b9ec-4f80-a93f-e8fadf6b0cb0)
