### PR TITLE
Added settings to hide posts in the feed immediately after being marked read via a tap

### DIFF
--- a/OpenArtemis/Utilities/Modifiers/Defaults.swift
+++ b/OpenArtemis/Utilities/Modifiers/Defaults.swift
@@ -27,6 +27,7 @@ extension Defaults.Keys {
     static let showJumpToNextCommentButton = Key<Bool>("showJumpToNextCommentButton", default: true)
     static let doLiveText = Key<Bool>("doLiveText", default: true)
     static let hideReadPosts = Key<Bool>("hideReadPosts", default: false)
+    static let hideReadPostsImmediately = Key<Bool>("hideReadPostsImmediately", default: true) // When a post is marked read, should it be hidden from the post list immediately, or should it show until the list is reloaded
     static let markReadOnScroll = Key<Bool>("markReadOnScroll", default: false)
     
     static let defaultPostPageSorting = Key<SortOption>("defaultPostPageSorting", default: SortOption.best)

--- a/OpenArtemis/Utilities/Post Utils/Post Utils.swift
+++ b/OpenArtemis/Utilities/Post Utils/Post Utils.swift
@@ -214,12 +214,12 @@ class PostUtils {
         return savedPost
     }
     
-    /// Toggles the read status of a `Post` entity.
+    /// Marks a`Post` entity as read after a small delay.
     ///
     /// - Parameters:
     ///   - context: The Core Data managed object context.
     ///   - postId: The identifier of the post to toggle.
-    func toggleRead(context: NSManagedObjectContext, postId: String) {
+    func markRead(context: NSManagedObjectContext, postId: String) {
         guard fetchReadPost(context: context, postId: postId) == nil else {
             // ReadPost already exists, no need to toggle
             return

--- a/OpenArtemis/Views/Favorites Drawer/SavedView.swift
+++ b/OpenArtemis/Views/Favorites Drawer/SavedView.swift
@@ -115,7 +115,7 @@ struct MixedContentView: View {
                 coordinator.path.append(PostResponse(post: post))
                 
                 if !isRead {
-                    PostUtils.shared.toggleRead(context: managedObjectContext, postId: post.id)
+                    PostUtils.shared.markRead(context: managedObjectContext, postId: post.id)
                 }
             }
         case .comment(let comment, _):

--- a/OpenArtemis/Views/Settings/SettingsView.swift
+++ b/OpenArtemis/Views/Settings/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
     @Default(.swipeAnywhere) var swipeAnywhere
     @Default(.hideReadPosts) var hideReadPosts
     @Default(.markReadOnScroll) var markReadOnScroll
+    @Default(.hideReadPostsImmediately) var hideReadPostsImmediately
     
     @Default(.showJumpToNextCommentButton) var showJumpToNextCommentButton
     
@@ -190,6 +191,7 @@ struct SettingsView: View {
                         .foregroundColor(.red)
                 })
                 Toggle("Hide Read Posts", isOn: $hideReadPosts)
+                Toggle("Hide Read Post Immediately", isOn: $hideReadPostsImmediately)
                 Toggle("Mark Posts Read on Scroll", isOn: $markReadOnScroll)
             }
             

--- a/OpenArtemis/Views/Subreddits/SubredditFeedView.swift
+++ b/OpenArtemis/Views/Subreddits/SubredditFeedView.swift
@@ -15,6 +15,7 @@ struct SubredditFeedView: View {
     @EnvironmentObject var trackingParamRemover: TrackingParamRemover
     @Default(.over18) var over18
     @Default(.hideReadPosts) var hideReadPosts
+    @Default(.hideReadPostsImmediately) var hideReadPostsImmediately
     @Default(.markReadOnScroll) var markReadOnScroll
 
     let subredditName: String
@@ -49,9 +50,9 @@ struct SubredditFeedView: View {
         sortDescriptors: []
     ) var readPosts: FetchedResults<ReadPost>
     
-    // Tracks posts that were just read due to scrolling, so we don't remove them until we reload
-    // This helps prevent the list from jumping around
-    @State private var justReadDueToScrollingPostIds: Set<String> = []
+    // Tracks posts that were just read this "session". This can be due to scrolling or because they clicked to read
+    // This helps prevent the list from jumping around if the posts were marked read due to scrolling
+    @State private var readThisSession: Set<String> = []
 
     // MARK: - Body
     var body: some View {
@@ -62,7 +63,7 @@ struct SubredditFeedView: View {
                         var isRead: Bool {
                             readPosts.contains(where: { $0.readPostId == post.id })
                         }
-                        let justRead = justReadDueToScrollingPostIds.contains(post.id)
+                        let justRead = readThisSession.contains(post.id)
                         
                         var isSaved: Bool {
                             savedPosts.contains { $0.id == post.id }
@@ -74,8 +75,8 @@ struct SubredditFeedView: View {
                             }
                             .if(markReadOnScroll, transform: { postFeedItem in
                                 postFeedItem.onScrolledOffTopOfScreen {
-                                    PostUtils.shared.toggleRead(context: managedObjectContext, postId: post.id)
-                                    justReadDueToScrollingPostIds.insert(post.id)
+                                    PostUtils.shared.markRead(context: managedObjectContext, postId: post.id)
+                                    readThisSession.insert(post.id)
                                 }
                             })
                         }
@@ -151,7 +152,10 @@ struct SubredditFeedView: View {
     private func handlePostTap(_ post: Post, isRead: Bool) {
         coordinator.path.append(PostResponse(post: post))
         if !isRead {
-            PostUtils.shared.toggleRead(context: managedObjectContext, postId: post.id)
+            PostUtils.shared.markRead(context: managedObjectContext, postId: post.id)
+            if (!hideReadPostsImmediately) {
+                readThisSession.insert(post.id)
+            }
         }
     }
     
@@ -239,7 +243,7 @@ struct SubredditFeedView: View {
             postIDs.removeAll()
             searchResults.removeAll()
             mixedMediaIDs.removeAll()
-            justReadDueToScrollingPostIds.removeAll()
+            readThisSession.removeAll()
             lastPostAfter = ""
             isLoading = false
         }


### PR DESCRIPTION
Description:
Added a setting to change the behavior of the subreddit feed when you tap to read a post and have the "hide read posts" setting enabled.
When this new feature is disabled, this allows a user to return to a post that they accidentally backed out of. I found that I often would back out of something accidentally when trying to collapse a thread and then "lost" the post.
 
Known issues, after changing setting, will not apply to previously read posts until the list is refreshed entirely.

Changes Made:
Added setting
Added behavior change

Video showing both settings
https://github.com/user-attachments/assets/5751b733-fbaf-4c66-8e8e-f6d27c7071fc
