### PR TITLE
WIP - Scroll performance fixes for when there are many read posts already

### DIFF
--- a/OpenArtemis/Views/Subreddits/SubredditFeedView.swift
+++ b/OpenArtemis/Views/Subreddits/SubredditFeedView.swift
@@ -76,7 +76,6 @@ struct SubredditFeedView: View {
                             }
                             .if(markReadOnScroll, transform: { postFeedItem in
                                 postFeedItem.onScrolledOffTopOfScreen {
-                                    // TODO: maybe make a function here to do all of these?
                                     readPostIDs.insert(post.id)
                                     PostUtils.shared.markRead(context: managedObjectContext, postId: post.id)
                                     readThisSession.insert(post.id)
@@ -241,7 +240,6 @@ struct SubredditFeedView: View {
                     for media in newMedia {
                         let mediaID = MiscUtils.extractMediaId(from: media)
                         if !mixedMediaIDs.contains(mediaID) {
-                            // TODO: should this honor isRead?
                             searchResults.append(media)
                             mixedMediaIDs.insert(mediaID)
                         }


### PR DESCRIPTION
Evaluating some alternatives to this that don't require a separate data structure.

Description:
After adding the "mark read on scroll" feature, it seemed like scrolling performance took a hit. With some of my limited Instruments experience, it seemed like this was related to looking through the read posts FetchedResults to determine isRead when it gets to be several hundred items large. If I made the incorrect determination, then this PR is likely focused on a poor fix.

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/8a37cada-f8b9-4801-9d03-d0617c909df7">

Altertnatives looked into: Adding an index. This didn't seem to help.

Changes:
Moved lookup to work off the main thread. This is at the expense of a slightly longer initial load for each page of content.
Removed an unused private function.
Keep track of read posts in memory for the current list.