### PR TITLE
Feature: Mark post as read when opening from media previews

### DIFF
--- a/OpenArtemis/Views/Posts/Media/EmbeddedMultiMediaView.swift
+++ b/OpenArtemis/Views/Posts/Media/EmbeddedMultiMediaView.swift
@@ -23,6 +23,8 @@ struct EmbeddedMultiMediaView: View {
     let textSizePreference: TextSizePreference
     
     @State private var isLoading: Bool = false
+        
+    let onTap: (() -> Void)?
     
     var body: some View {
         let layout = useLargeThumbnail ? AnyLayout(VStackLayout()) : AnyLayout(HStackLayout())
@@ -95,6 +97,7 @@ struct EmbeddedMultiMediaView: View {
         .padding(appTheme.compactMode || forceCompactMode ? 0 : 6) // less spacing in compact ^.^
         .background(RoundedRectangle(cornerRadius: 6).foregroundColor(tagBgColor).opacity(appTheme.compactMode || forceCompactMode ? 0 : 1))
         .onTapGesture {
+            onTap?()
             if !isLoading {
                 withAnimation {
                     isLoading = true

--- a/OpenArtemis/Views/Posts/Media/MediaView.swift
+++ b/OpenArtemis/Views/Posts/Media/MediaView.swift
@@ -24,6 +24,8 @@ struct MediaView: View {
     
     @Binding var mediaSize: CGSize
     
+    let onTap: (() -> Void)?
+    
     var body: some View {
         VStack {
             let forcedPrivateMediaURL = URL(string: mediaURL.privateURL)!
@@ -63,6 +65,7 @@ struct MediaView: View {
                 .aspectRatio(contentMode: .fit)
                 .onTapGesture {
                     ImageViewerController(images: [mediaURL.privateURL], imageTitle: title).present()
+                    onTap?()
                 }
                 .cornerRadius(6)
                 
@@ -74,7 +77,7 @@ struct MediaView: View {
                         .foregroundStyle(Color.white.opacity(0.75))
                 }
             default:
-                EmbeddedMultiMediaView(determinedType: determinedType, mediaURL: mediaURL, thumbnailURL: thumbnailURL, useLargeThumbnail: useLargeThumbnail, title: title, forceCompactMode: forceCompactMode, appTheme: appTheme, textSizePreference: textSizePreference)
+                EmbeddedMultiMediaView(determinedType: determinedType, mediaURL: mediaURL, thumbnailURL: thumbnailURL, useLargeThumbnail: useLargeThumbnail, title: title, forceCompactMode: forceCompactMode, appTheme: appTheme, textSizePreference: textSizePreference, onTap: onTap)
             }
         }
         .background(


### PR DESCRIPTION
## Description
Updates the behavior from the media previews (image and multimedia) to set the post as read when opened by taping them.

## Changes Made
- Modified the `EmbeddedMultiMediaView` to receive an `onTap` callback and call it when tapped;
- Modified the `MediaView` to receive an `onTap` callback and:
  - call it when the type is image;
  - pass it along to the `EmbeddedMultiMediaView`
- Modified the `PostFeedView` to pass the `PostUtils.shared.markRead` to the previews to be called on tap;

## Expected behavior
Given the user is on the feed view (home, all, favorites, subreddit, ...)
And there are posts with previews (image, video, url)
When the user tap the preview
Then the preview should load the image/video/url
When going back to the feed
Then the post should be marked as read